### PR TITLE
Fix to correctly handle browsers's HTTP_ACCEPT_LANGUAGE correctly

### DIFF
--- a/action.php
+++ b/action.php
@@ -47,7 +47,8 @@ class action_plugin_uilanguage extends DokuWiki_Action_Plugin {
             // 3. Set the UI language to one of the browser's accepted languages
             $languages = split(',', preg_replace('/\(;q=\d+\.\d+\)/i', '', getenv('HTTP_ACCEPT_LANGUAGE')));
             foreach ($languages as $l) {
-                if ($this->langOK($l)) {
+            	$l = substr($l, 0, strpos($l, ';'));
+					if ($this->langOK($l)) {
                     $conf['lang'] = $l;
                     break;
                 }

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   uilanguage
 author Viktor Söderqvist
 email  viktor@zuiderkwast.se
-date   2013-08-19
+date   2016-11-16
 name   UI Language plugin
 desc   Changes the user interface language to match the language of the current page
 url    https://www.dokuwiki.org/plugin:uilanguage


### PR DESCRIPTION
Fix to correctly handle browsers's HTTP_ACCEPT_LANGUAGE correctly which can contain a qvalue (e.g. 'en-US;q=0.5')

Bump version to today's date.