### PR TITLE
split() has been replaced by preg_split() in php7

### DIFF
--- a/action.php
+++ b/action.php
@@ -45,7 +45,7 @@ class action_plugin_uilanguage extends DokuWiki_Action_Plugin {
                 }
             }
             // 3. Set the UI language to one of the browser's accepted languages
-            $languages = split(',', preg_replace('/\(;q=\d+\.\d+\)/i', '', getenv('HTTP_ACCEPT_LANGUAGE')));
+            $languages = preg_split(',', preg_replace('/\(;q=\d+\.\d+\)/i', '', getenv('HTTP_ACCEPT_LANGUAGE')));
             foreach ($languages as $l) {
                 if ($this->langOK($l)) {
                     $conf['lang'] = $l;


### PR DESCRIPTION
See issue #4. preg_split() is compatible with php4, php5 and php7.